### PR TITLE
Allow empty string instance for lb hostnames

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -119,7 +119,7 @@ class Borg
   default: (o) => @server = _.merge o, @server
 
   server_name: ({ datacenter, env, type, instance, subproject, tld }) =>
-    instance ||= '01'
+    instance = '01' if instance is null
     subproject ||= @server.subproject ||= ''
     "#{datacenter or @server.datacenter}-#{env or @server.env}-#{type}#{instance}#{subproject && '-'+subproject}.#{tld or @server.tld}"
 


### PR DESCRIPTION
Only set instance to 01 if it's null so that an empty string can be provided to create hostnames without an instance ID (such as for load balancers).