### PR TITLE
Revert changes to map_servers

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -169,7 +169,7 @@ class Borg
         subproject: subprojects
         tlds: tlds
         required: required
-      results = results.push map_cb server
+      results = results.concat _.map server, map_cb
     return results
 
   eachServer: (each_cb) ->


### PR DESCRIPTION
- Found needed functionality in find_server, so there's no need for map_servers to return the objects