### PR TITLE
default permitReboot to true when assembling a server

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -528,6 +528,7 @@ class Borg
     # unless the user specifies otherwise via cli --locals=ssh:port:
     locals.ssh ||= {}
     locals.ssh.port ||= 22
+    locals.permitReboot = true unless locals.permitReboot = false
     @create locals, =>
       @assimilate locals, cb
         # TODO: also run checkup


### PR DESCRIPTION
To allow passing a variable to allow automatic reboots during assimilation if needed
